### PR TITLE
Some fixes

### DIFF
--- a/OBSlider/OBSlider.h
+++ b/OBSlider/OBSlider.h
@@ -14,4 +14,10 @@
 @property (strong, nonatomic) NSArray *scrubbingSpeeds;
 @property (strong, nonatomic) NSArray *scrubbingSpeedChangePositions;
 
+/**
+ On iOS 7+ is a glitch when beginTrackingWithTouch:touch:withEvent is called
+ Default is NO, for compatibility reasons
+ */
+@property (assign, nonatomic) BOOL shouldNotCallSuperOnBeginTracking;
+
 @end

--- a/OBSlider/OBSlider.m
+++ b/OBSlider/OBSlider.m
@@ -28,7 +28,7 @@
 @synthesize scrubbingSpeed = _scrubbingSpeed;
 @synthesize scrubbingSpeeds = _scrubbingSpeeds;
 @synthesize scrubbingSpeedChangePositions = _scrubbingSpeedChangePositions;
-@synthesize beganTrackingLocation = _beganTrackkingLocation;
+@synthesize beganTrackingLocation = _beganTrackingLocation;
 @synthesize realPositionValue = _realPositionValue;
 @synthesize beganTrackingValue = _beganTrackingValue;
 

--- a/OBSliderDemo/Classes/OBSliderDemoViewController.m
+++ b/OBSliderDemo/Classes/OBSliderDemoViewController.m
@@ -25,6 +25,10 @@
 - (void)viewDidLoad 
 {
     [super viewDidLoad];
+	
+	// fix glitch on iOS 7+
+	self.slider.shouldNotCallSuperOnBeginTracking = [[UIDevice currentDevice].systemVersion compare:@"7.0" options:NSNumericSearch] != NSOrderedAscending;
+
 }
 
 - (void)viewDidUnload 

--- a/OBSliderDemo/OBSliderDemo.xcodeproj/project.xcworkspace/xcshareddata/OBSliderDemo.xccheckout
+++ b/OBSliderDemo/OBSliderDemo.xcodeproj/project.xcworkspace/xcshareddata/OBSliderDemo.xccheckout
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
+	<false/>
+	<key>IDESourceControlProjectIdentifier</key>
+	<string>50B3B789-B8BF-4CF5-920F-A0432D524088</string>
+	<key>IDESourceControlProjectName</key>
+	<string>OBSliderDemo</string>
+	<key>IDESourceControlProjectOriginsDictionary</key>
+	<dict>
+		<key>E762CD65D845A389E722D635E1047A2B49FAD434</key>
+		<string>https://github.com/shc-vj/OBSlider.git</string>
+	</dict>
+	<key>IDESourceControlProjectPath</key>
+	<string>OBSliderDemo/OBSliderDemo.xcodeproj</string>
+	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
+	<dict>
+		<key>E762CD65D845A389E722D635E1047A2B49FAD434</key>
+		<string>../../..</string>
+	</dict>
+	<key>IDESourceControlProjectURL</key>
+	<string>https://github.com/shc-vj/OBSlider.git</string>
+	<key>IDESourceControlProjectVersion</key>
+	<integer>111</integer>
+	<key>IDESourceControlProjectWCCIdentifier</key>
+	<string>E762CD65D845A389E722D635E1047A2B49FAD434</string>
+	<key>IDESourceControlProjectWCConfigurations</key>
+	<array>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>E762CD65D845A389E722D635E1047A2B49FAD434</string>
+			<key>IDESourceControlWCCName</key>
+			<string>OBSlider</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/README.mdown
+++ b/README.mdown
@@ -1,3 +1,11 @@
+##### This fork fixes some issues:
+
+- property shouldNotCallSuperOnBeginTracking was added, because on iOS 7+ call to UISlider beginTrackingWithTouch:touch withEvent:event causes glitch (its default value is NOT for compatibility)
+- original slider value on begin tracking is remembered and on endTrackingWithTouch:touch withEvent: is compared with current value, only if different sendActionsForControlEvents:UIControlEventValueChanged is sent
+- on endTrackingWithTouch:withEvent:  property 'tracking' of UISlider is set (using KVC), originally it's responsibility of [UISlider  endTrackingWithTouch:withEvent:]
+
+##### Original description
+
 # OBSlider
 
 A `UISlider` subclass that adds variable scrubbing speeds (as seen in the iPod app on iOS) to `UISlider`.


### PR DESCRIPTION
- property shouldNotCallSuperOnBeginTracking was added, because on iOS 7+ call to UISlider beginTrackingWithTouch:touch withEvent:event causes glitch
- original slider value on begin tracking is remembered and on endTrackingWithTouch:touch withEvent: is compared with current value, only if different sendActionsForControlEvents:UIControlEventValueChanged is sent
- on endTrackingWithTouch:withEvent:  property 'tracking' of UISlider is set (using KVC), originally it's responsibility of [UISlider  endTrackingWithTouch:withEvent:]

Sample project was updated to properly set shouldNotCallSuperOnBeginTracking property on slider